### PR TITLE
feat: change default agent backend from codex to claude

### DIFF
--- a/apps/cli/src/stores/use-preferences.ts
+++ b/apps/cli/src/stores/use-preferences.ts
@@ -20,7 +20,7 @@ interface PreferencesStore {
 export const usePreferencesStore = create<PreferencesStore>()(
   persist(
     (set) => ({
-      agentBackend: "codex" as AgentBackend,
+      agentBackend: "claude" as AgentBackend,
       autoRunAfterPlanning: false,
       skipPlanning: true,
       autoSaveFlows: true,

--- a/packages/supervisor/src/constants.ts
+++ b/packages/supervisor/src/constants.ts
@@ -1,4 +1,4 @@
-export const DEFAULT_AGENT_PROVIDER = "codex";
+export const DEFAULT_AGENT_PROVIDER = "claude";
 export const BROWSER_TEST_MODEL = "claude-sonnet-4-6";
 export const SHARE_DIRECTORY_PREFIX = "browser-tester-share-";
 export const COMMENT_DIRECTORY_PREFIX = "browser-tester-comment-";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Changes the default AI agent backend from `codex` to `claude` across the application.

## Problem

When using the default `codex` backend, users encounter persistent authentication errors:

```
Planning failed: Codex run failed: Error: Codex Exec exited with code 1
ERROR codex_core::auth: Failed to refresh token: 401 Unauthorized
"refresh_token_reused"
```

The Codex backend requires OpenAI authentication tokens that frequently expire, causing the "EXECUTING BROWSER PLAN" screen to fail with `0/0` steps and a `Planning failed` error.

## Changes

Two files changed:

1. **`apps/cli/src/stores/use-preferences.ts`** — Default `agentBackend` changed from `"codex"` to `"claude"`
2. **`packages/supervisor/src/constants.ts`** — `DEFAULT_AGENT_PROVIDER` changed from `"codex"` to `"claude"`

## Impact

- The interactive TUI now defaults to Claude when no `--agent` flag is provided
- The headless CLI mode already defaulted to Claude (`options.agent ?? "claude"` in `run-test.ts`)
- Users can still explicitly select Codex via `--agent codex` or the preferences UI
- No breaking changes — the `"codex"` backend remains fully available
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-74772ca2-412b-4145-8877-3d6adc5aadc9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-74772ca2-412b-4145-8877-3d6adc5aadc9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

