### PR TITLE
fix: remove hardcoded PostHog API key from analytics

### DIFF
--- a/packages/shared/src/analytics/analytics.ts
+++ b/packages/shared/src/analytics/analytics.ts
@@ -1,4 +1,4 @@
-import { Effect, Layer, Schema, ServiceMap } from "effect";
+import { Config, Effect, Layer, Schema, ServiceMap } from "effect";
 import { ChildProcess } from "effect/unstable/process";
 import { ChildProcessSpawner } from "effect/unstable/process/ChildProcessSpawner";
 import { NodeServices } from "@effect/platform-node";
@@ -8,10 +8,9 @@ import { PostHog } from "posthog-node";
 
 import type { EventMap } from "./analytics-events";
 
-const POSTHOG_API_KEY = "phc_t5FKk9mlc4pKbbBimiIlrM5Acq9meRp1FSuNjmwxjAX";
+const POSTHOG_API_KEY_ENV_NAME = "POSTHOG_API_KEY";
+const POSTHOG_HOST_ENV_NAME = "POSTHOG_HOST";
 const POSTHOG_DEFAULT_HOST = "https://us.i.posthog.com";
-
-const posthogClient = new PostHog(POSTHOG_API_KEY, { host: POSTHOG_DEFAULT_HOST });
 
 const ClaudeAuthStatusResponse = Schema.Struct({
   email: Schema.String,
@@ -74,27 +73,37 @@ export class AnalyticsProvider extends ServiceMap.Service<
   AnalyticsProvider,
   AnalyticsProviderShape
 >()("@expect/AnalyticsProvider") {
-  static layerPostHog = Layer.succeed(this)({
-    capture: (event) =>
-      Effect.sync(() => {
-        posthogClient.captureImmediate({
-          event: event.eventName,
-          properties: event.properties,
-          distinctId: event.distinctId,
-        });
-      }),
-    identify: (params) =>
-      Effect.sync(() => {
-        posthogClient.identify({
-          distinctId: params.distinctId,
-          properties: { email: params.email, ...(params.name ? { name: params.name } : {}) },
-        });
-      }),
-    flush: Effect.tryPromise({
-      try: () => posthogClient.flush(),
-      catch: (cause) => cause,
-    }).pipe(Effect.ignore),
-  });
+  static layerPostHog = Layer.effect(this)(
+    Effect.gen(function* () {
+      const posthogApiKey = yield* Config.string(POSTHOG_API_KEY_ENV_NAME);
+      const posthogHost = yield* Config.string(POSTHOG_HOST_ENV_NAME).pipe(
+        Config.withDefault(POSTHOG_DEFAULT_HOST),
+      );
+      const posthogClient = new PostHog(posthogApiKey, { host: posthogHost });
+
+      return {
+        capture: (event) =>
+          Effect.sync(() => {
+            posthogClient.captureImmediate({
+              event: event.eventName,
+              properties: event.properties,
+              distinctId: event.distinctId,
+            });
+          }),
+        identify: (params) =>
+          Effect.sync(() => {
+            posthogClient.identify({
+              distinctId: params.distinctId,
+              properties: { email: params.email, ...(params.name ? { name: params.name } : {}) },
+            });
+          }),
+        flush: Effect.tryPromise({
+          try: () => posthogClient.flush(),
+          catch: (cause) => cause,
+        }).pipe(Effect.ignore),
+      } as const;
+    }),
+  );
 
   static layerDev = Layer.succeed(this)({
     capture: (event) =>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- removed the hardcoded PostHog API key from `packages/shared/src/analytics/analytics.ts`
- switched PostHog initialization to runtime config:
  - `POSTHOG_API_KEY` (required)
  - `POSTHOG_HOST` (optional, defaults to `https://us.i.posthog.com`)
- preserved existing analytics behavior while eliminating committed credential material

## Validation
- `gitleaks git` full-history scan identified one leak in prior commit history
- updated source to remove the in-repo key constant
- `gitleaks dir` scan after code change showed no source-file secret hits (remaining hit was only from temporary scan report and was removed)

## Notes
- full-history leak still exists on `main` in commit `49399527e023a25929100ac85b83dbb44dfdebc2`; repository-wide history rewrite/cleanup should be coordinated on default branch and credential should be rotated.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://million-js.slack.com/archives/C09BLPH3B1R/p1774444477561189?thread_ts=1774444477.561189&cid=C09BLPH3B1R)

<div><a href="https://cursor.com/agents/bc-6e53ee7b-5680-5006-a7a6-9f7bb1556ac1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6e53ee7b-5680-5006-a7a6-9f7bb1556ac1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

