### PR TITLE
fix: correct NO_TELEMTRY typo to NO_TELEMETRY

### DIFF
--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -41,7 +41,7 @@ Examples:
   $ expect-cli --target branch                          test all branch changes
   $ expect-cli --target unstaged                        test unstaged changes
 
-Set `NO_TELEMTRY=1` to disable analytics events.
+Set `NO_TELEMETRY=1` to disable analytics events.
 ```
 
 ## How it works

--- a/packages/shared/src/analytics/analytics.ts
+++ b/packages/shared/src/analytics/analytics.ts
@@ -84,7 +84,7 @@ export class AnalyticsProvider extends ServiceMap.Service<
 export class Analytics extends ServiceMap.Service<Analytics>()("@expect/Analytics", {
   make: Effect.gen(function* () {
     const provider = yield* AnalyticsProvider;
-    const noTelemetryValue = yield* Config.option(Config.string("NO_TELEMTRY"));
+    const noTelemetryValue = yield* Config.option(Config.string("NO_TELEMETRY"));
     const telemetryDisabled = Option.match(noTelemetryValue, {
       onNone: () => false,
       onSome: (value) => value === "1",


### PR DESCRIPTION
## Summary
- Fixes typo in the `NO_TELEMETRY` environment variable name (was `NO_TELEMTRY`, missing the second E)
- Updated in both the CLI README and the analytics config reader in `packages/shared/src/analytics/analytics.ts`

## Note
This is a breaking change for anyone currently using `NO_TELEMTRY=1` — they would need to update to `NO_TELEMETRY=1`.