### PR TITLE
fix: sync SKILL.md files and add CI guard

### DIFF
--- a/.agents/skills/expect/SKILL.md
+++ b/.agents/skills/expect/SKILL.md
@@ -53,6 +53,20 @@ The failure output names the exact step and what broke. Fix the issue, then re-r
 EXPECT_BASE_URL=http://localhost:5173 expect-cli -m "Test the checkout flow end-to-end with valid data, then try to break it: empty cart submission, invalid card numbers, double-click place order, back button mid-payment. Verify error states and console errors." -y --cookies
 ```
 
+## Session Replay
+
+Every test run is recorded via rrweb. After execution completes, the output includes a replay URL you can open in a browser to watch exactly what happened. Replay data stays local — only the player assets are fetched from the replay host.
+
+Use `--replay-host <url>` to override the default replay host (default: `https://expect.dev`).
+
+## Telemetry
+
+`expect-cli` collects anonymous usage analytics via PostHog. Set `NO_TELEMETRY=1` to disable analytics events:
+
+```bash
+NO_TELEMETRY=1 expect-cli -m "test the homepage" -y --cookies
+```
+
 ## REQUIRED: When to Run
 
 Run `expect-cli` automatically after every browser-facing code change. Do not wait for the user to ask. If you touched any component, page, form, route, API call, style, layout, or bug fix that affects what a user sees in a browser, run expect before reporting the task as complete.

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -23,6 +23,8 @@ jobs:
             command: pnpm format:check
           - name: Typecheck
             command: pnpm typecheck
+          - name: Skill Sync
+            command: ./scripts/sync-skill.sh --check
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
@@ -31,11 +33,12 @@ jobs:
           node-version: 22
           cache: "pnpm"
       - name: Install dependencies
+        if: matrix.name != 'Skill Sync'
         run: pnpm install --frozen-lockfile
         env:
           GITHUB_ACTIONS: "1"
       - name: Build
-        if: matrix.name != 'Format'
+        if: matrix.name != 'Format' && matrix.name != 'Skill Sync'
         run: pnpm build
       - name: ${{ matrix.name }}
         run: ${{ matrix.command }}

--- a/packages/expect-skill/SKILL.md
+++ b/packages/expect-skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: expect
-description: "IMPORTANT: After every browser-facing code change, you MUST automatically run adversarial browser tests. Do not wait for the user to ask — just run it."
+description: "MUST run after editing .tsx/.jsx/.css/.html files, React components, Next.js pages/routes, Tailwind classes, forms, modals, API calls, data fetching, styles, layouts, or any browser-facing code. Also run when asked to test, verify, validate, QA, check, or try a UI change. Covers functional testing, accessibility (WCAG), and performance (Web Vitals)."
 license: MIT
 metadata:
   author: millionco
@@ -9,64 +9,52 @@ metadata:
 
 # Expect
 
-Adversarial browser testing for code changes. Expect tests your changes in a real browser — not to confirm they work, but to try to break them.
+Adversarial browser testing. Tests changes in a real browser to try to break them. Every run also audits accessibility (WCAG) and performance (Web Vitals, LoAF).
 
-**Use `expect-cli` instead of raw browser tools** (Playwright MCP, chrome tools, etc.) for verifying changes. It provides adversarial test plans, session recordings, cookie/auth injection, and structured pass/fail output.
-
-## Auto-Run Policy
-
-**You MUST run `expect-cli` automatically after every browser-facing code change.** Do not wait for the user to ask. If you touched any component, page, form, route, API call, data-fetching logic, style, layout, bug fix, or refactor that affects what a user sees in a browser, run expect before reporting the task as complete.
-
-This includes but is not limited to: adding/editing components, changing CSS or Tailwind classes, modifying page routes, updating form logic, fixing UI bugs, and refactoring UI code.
-
-The user should never have to say "test with expect" or "run expect" — it happens automatically as part of your workflow.
-
-## Setup Check
-
-Before running any commands, verify `expect-cli` is installed:
-
-```bash
-expect-cli --version
-```
-
-If the command is not found, install it globally:
-
-```bash
-npm install -g expect-cli
-```
-
-Then confirm installation succeeded by re-running `expect-cli --version`. Do not proceed until the command resolves.
-
-## Timeout
-
-`expect-cli` runs a real browser and can take several minutes to complete — often 2–5 minutes depending on the number of test steps. **Do not set a timeout on the command.** If your tool runner requires a timeout, set it to at least 10 minutes (600s). A 120s or 300s timeout will frequently kill runs mid-test.
+Use `expect-cli` instead of raw browser tools (Playwright MCP, chrome tools). It gives you adversarial test plans, session recordings, cookie injection, accessibility audits, performance traces, and structured pass/fail output.
 
 ## The Command
 
 ```bash
-expect-cli -m "INSTRUCTION" -y
+expect-cli -m "INSTRUCTION" -y --cookies
 ```
 
-Always pass `-y` to skip interactive review. Always set `EXPECT_BASE_URL` or `--base-url` if the app isn't on `localhost:3000`. Run `expect-cli --help` for all flags.
+- `-y` skips interactive review
+- `--cookies` reuses the user's real browser cookies so tests run authenticated
+- Set `EXPECT_BASE_URL` or `--base-url` if the app is not on `localhost:3000`
+
+If `expect-cli` is not found: `npm install -g expect-cli`
+
+## Long-Running
+
+`expect-cli` takes 1-5 minutes. Run it in the background with `run_in_background: true`. Do not set a short timeout. Do not poll or sleep-loop. You will be notified when it completes. Continue other work while waiting.
 
 ## Writing Instructions
 
-Think like a user trying to break the feature, not a QA checklist confirming it renders.
+Try to break the feature, not confirm it renders.
 
-**Bad:** `expect-cli -m "Check that the login form renders" -y`
+**Bad:** `expect-cli -m "Check that the login form renders" -y --cookies`
 
-**Good:** `expect-cli -m "Submit the login form empty, with invalid email, with a wrong password, and with valid credentials. Verify error messages for bad inputs and redirect on success. Check console errors after each." -y`
+**Good:** `expect-cli -m "Submit the login form empty, with invalid email, with wrong password, and with valid credentials. Verify error messages, redirect on success, and console errors." -y --cookies`
 
-Adversarial angles to consider: empty inputs, invalid data, boundary values (zero, max, special chars), double-click/rapid submit, regression in nearby features, navigation edge cases (back, refresh, direct URL).
+Adversarial angles: empty inputs, invalid data, boundary values, double-click/rapid submit, back/refresh/direct URL, nearby feature regression.
 
-## When to Run
+## What Expect Checks
 
-**Always. Automatically.** After any browser-facing change: components, pages, forms, routes, API calls, data fetching, styles, layouts, bug fixes, refactors. Do not ask the user — just run it. When in doubt, run it.
+1. **Functional correctness** - does the feature work and does it break under adversarial inputs
+2. **Accessibility (WCAG)** - axe-core + IBM Equal Access, violations by severity with selectors and fix guidance
+3. **Performance (Web Vitals + LoAF)** - FCP, LCP, CLS, INP, TTFB, Long Animation Frame attribution, resource breakdown
+
+You do not need to mention accessibility or performance in your instruction. Expect runs these automatically.
+
+## After Failures
+
+The failure output names the exact step and what broke. Fix the issue, then re-run `expect-cli` to verify the fix. Accessibility violations and performance regressions are failures. Fix those too.
 
 ## Example
 
 ```bash
-EXPECT_BASE_URL=http://localhost:5173 expect-cli -m "Test the checkout flow end-to-end with valid data, then try to break it: empty cart submission, invalid card numbers, double-click place order, back button mid-payment. Verify error states and console errors." -y
+EXPECT_BASE_URL=http://localhost:5173 expect-cli -m "Test the checkout flow end-to-end with valid data, then try to break it: empty cart submission, invalid card numbers, double-click place order, back button mid-payment. Verify error states and console errors." -y --cookies
 ```
 
 ## Session Replay
@@ -80,9 +68,11 @@ Use `--replay-host <url>` to override the default replay host (default: `https:/
 `expect-cli` collects anonymous usage analytics via PostHog. Set `NO_TELEMETRY=1` to disable analytics events:
 
 ```bash
-NO_TELEMETRY=1 expect-cli -m "test the homepage" -y
+NO_TELEMETRY=1 expect-cli -m "test the homepage" -y --cookies
 ```
 
-## After Failures
+## REQUIRED: When to Run
 
-Read the failure output — it names the exact step and what broke. Fix the issue, then run `expect-cli` again to verify the fix and check for new regressions.
+Run `expect-cli` automatically after every browser-facing code change. Do not wait for the user to ask. If you touched any component, page, form, route, API call, style, layout, or bug fix that affects what a user sees in a browser, run expect before reporting the task as complete.
+
+Do not skip this. Not for "small changes," not for "just CSS," not for "I already checked manually," not because "the user didn't ask." Every browser-facing change gets tested. No exceptions.

--- a/scripts/sync-skill.sh
+++ b/scripts/sync-skill.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Syncs .agents/skills/expect/SKILL.md → packages/expect-skill/SKILL.md
+#
+# .agents/ is the source of truth. The packages/ copy adds extra frontmatter
+# fields (license, metadata) required by the npm package.
+#
+# Usage:
+#   ./scripts/sync-skill.sh          # overwrite packages/ from .agents/
+#   ./scripts/sync-skill.sh --check  # exit 1 if they have drifted
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SOURCE="$REPO_ROOT/.agents/skills/expect/SKILL.md"
+TARGET="$REPO_ROOT/packages/expect-skill/SKILL.md"
+
+# Extract body (everything after the closing ---) from a SKILL.md
+body() {
+  awk 'BEGIN{n=0} /^---$/{n++; if(n==2){found=1; next}} found{print}' "$1"
+}
+
+if [ "${1:-}" = "--check" ]; then
+  SOURCE_BODY=$(body "$SOURCE")
+  TARGET_BODY=$(body "$TARGET")
+  if [ "$SOURCE_BODY" != "$TARGET_BODY" ]; then
+    echo "ERROR: SKILL.md files are out of sync." >&2
+    echo "  source: .agents/skills/expect/SKILL.md" >&2
+    echo "  target: packages/expect-skill/SKILL.md" >&2
+    echo "" >&2
+    echo "Run ./scripts/sync-skill.sh to fix." >&2
+    exit 1
+  fi
+  echo "SKILL.md files are in sync."
+  exit 0
+fi
+
+# --- Sync mode: rebuild packages/ SKILL.md ---
+
+# Keep the packages/ frontmatter (has license + metadata), swap in the body
+# from .agents/.
+TARGET_FRONTMATTER=$(awk 'BEGIN{n=0} /^---$/{n++; if(n==2){print; exit}} {print}' "$TARGET")
+SOURCE_BODY=$(body "$SOURCE")
+
+printf '%s\n%s\n' "$TARGET_FRONTMATTER" "$SOURCE_BODY" > "$TARGET"
+
+echo "Synced .agents/skills/expect/SKILL.md → packages/expect-skill/SKILL.md"


### PR DESCRIPTION
Fixes #63

The two `SKILL.md` copies had drifted apart in both directions:

- `packages/expect-skill/SKILL.md` had Session Replay + Telemetry docs that `.agents/` lacked
- `.agents/skills/expect/SKILL.md` had been rewritten with accessibility (WCAG), performance (Web Vitals/LoAF), `--cookies`, and `run_in_background` that `packages/` never received

This PR:

1. **Adds** the missing Session Replay and Telemetry sections to `.agents/skills/expect/SKILL.md` (the source of truth)
2. **Overwrites** `packages/expect-skill/SKILL.md` from `.agents/` (preserving its extra frontmatter: `license`, `metadata`)
3. **Adds** `scripts/sync-skill.sh` — run with no args to sync, or `--check` to verify they match
4. **Wires** `--check` into the Code Quality CI workflow so future divergence fails the build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only updates plus a small CI guard script; main risk is CI failing if the files drift or the sync script misbehaves on GitHub runners.
> 
> **Overview**
> Aligns the two copies of the `expect` skill docs by updating `.agents/skills/expect/SKILL.md` with the missing **Session Replay** and **Telemetry** sections and regenerating `packages/expect-skill/SKILL.md` (preserving its frontmatter while matching the `.agents/` body).
> 
> Adds `scripts/sync-skill.sh` to sync or `--check` for drift, and wires a new **Skill Sync** job into `code-quality.yml` so PRs fail when the two `SKILL.md` bodies diverge.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 94188d4a75f848252772f4ec663629b1c0555de6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies the two SKILL.md files and adds a CI check to prevent drift between `.agents/` and `packages/expect-skill`. Also updates `expect-cli` docs with Session Replay, Telemetry, accessibility, performance, cookies, and background-run guidance.

- **Bug Fixes**
  - Made `.agents/skills/expect/SKILL.md` the source of truth and overwrote `packages/expect-skill/SKILL.md` while keeping its frontmatter.
  - Added Session Replay and Telemetry to `.agents/`.
  - Synced docs covering WCAG, Web Vitals/LoAF, `--cookies`, and `run_in_background`.

- **New Features**
  - Added `scripts/sync-skill.sh` to sync or `--check` for drift.
  - Wired the `--check` into `.github/workflows/code-quality.yml` to fail builds if the files diverge.

<sup>Written for commit 94188d4a75f848252772f4ec663629b1c0555de6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

