### PR TITLE
docs: add ManagedRuntime usage guidance to AGENTS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -651,6 +651,14 @@ describe("My Effect tests", () => {
   - `@effect/sql-mysql2`: MySQL
 - `ManagedRuntime` from `effect`: Integrate Effect with 3rd party frameworks like React.
 
+### ManagedRuntime guidance
+
+`ManagedRuntime` is an escape hatch for calling Effect code from outside Effect code (similar to how `useEffect` bridges side effects in React). Do not use `ManagedRuntime` when you are already inside Effect code.
+
+`ManagedRuntime` owns layer lifecycle. Running an Effect through a `ManagedRuntime` constructs and manages its layers. If your app already constructs layers through `layerCli`, introducing a `ManagedRuntime` can initialize a second copy of those layers (once via `layerCli`, once via `ManagedRuntime`).
+
+In this codebase, prefer the layer already provided by `layerCli` instead of creating a separate `ManagedRuntime`. If you need `ManagedRuntime` semantics, make `layerCli` return a `ManagedRuntime` so layers are constructed once.
+
 Use the `effect_docs_search` MCP tool to find more information about these modules.
 
 ## React Compiler


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a new **ManagedRuntime guidance** subsection in `AGENTS.md`
- clarify that `ManagedRuntime` is an escape hatch for invoking Effect code from non-Effect contexts
- document that `ManagedRuntime` manages layer lifecycle and can initialize duplicate layers when `layerCli` already constructs them
- recommend preferring layers from `layerCli`, or alternatively making `layerCli` return a `ManagedRuntime` so layers are constructed once

## Testing
- not applicable (documentation-only change)
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://million-js.slack.com/archives/C09BLPH3B1R/p1775111551475649?thread_ts=1775111551.475649&cid=C09BLPH3B1R)

<div><a href="https://cursor.com/agents/bc-3be3b1e5-2845-52db-b02c-0ba80c19754f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3be3b1e5-2845-52db-b02c-0ba80c19754f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `ManagedRuntime` usage guidance to `AGENTS.md`, clarifying when to use it and how it manages layer lifecycle. Notes that `ManagedRuntime` can duplicate layer initialization if layers are already constructed by `layerCli`, and recommends using `layerCli`-provided layers or having `layerCli` return a `ManagedRuntime` to ensure a single construction path.

<sup>Written for commit 75abe472b56d26331dbb5f52d0076aefe0521756. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

