### PR TITLE
fix(cli): replace pre-existing expect skill folders with symlinks

### DIFF
--- a/apps/cli/src/commands/add-skill.ts
+++ b/apps/cli/src/commands/add-skill.ts
@@ -92,6 +92,14 @@ const downloadSkill = async (skillDir: string): Promise<boolean> => {
   }
 };
 
+const getPathStats = (path: string) => {
+  try {
+    return lstatSync(path);
+  } catch {
+    return undefined;
+  }
+};
+
 const selectAgents = async (agents: readonly SupportedAgent[], nonInteractive: boolean) => {
   if (nonInteractive) return [...agents];
 
@@ -122,8 +130,8 @@ export const ensureAgentSymlink = (projectRoot: string, agent: SupportedAgent): 
   const targetPath = relative(dirname(symlinkPath), skillSourceDir);
 
   try {
-    if (existsSync(symlinkPath)) {
-      const stats = lstatSync(symlinkPath);
+    const stats = getPathStats(symlinkPath);
+    if (stats) {
       if (stats.isSymbolicLink()) {
         if (readlinkSync(symlinkPath) === targetPath) return true;
         unlinkSync(symlinkPath);

--- a/apps/cli/tests/add-skill.test.ts
+++ b/apps/cli/tests/add-skill.test.ts
@@ -6,6 +6,7 @@ import {
   readdirSync,
   readlinkSync,
   rmSync,
+  symlinkSync,
   writeFileSync,
 } from "node:fs";
 import { join } from "node:path";
@@ -126,6 +127,25 @@ describe("ensureAgentSymlink", () => {
       mkdirSync(join(projectRoot, ".agents", "skills", "expect"), { recursive: true });
       mkdirSync(join(projectRoot, ".codex", "skills", "expect"), { recursive: true });
       writeFileSync(join(projectRoot, ".codex", "skills", "expect", "old-file.txt"), "legacy");
+
+      const result = ensureAgentSymlink(projectRoot, "codex");
+
+      expect(result).toBe(true);
+      const linkedPath = join(projectRoot, ".codex", "skills", "expect");
+      expect(lstatSync(linkedPath).isSymbolicLink()).toBe(true);
+      expect(readlinkSync(linkedPath)).toBe("../../.agents/skills/expect");
+    } finally {
+      rmSync(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("replaces a broken symlink expect path with a valid symlink", () => {
+    const projectRoot = mkdtempSync(join(tmpdir(), "ensure-symlink-broken-"));
+
+    try {
+      mkdirSync(join(projectRoot, ".agents", "skills", "expect"), { recursive: true });
+      mkdirSync(join(projectRoot, ".codex", "skills"), { recursive: true });
+      symlinkSync("../../../.agents/skills/does-not-exist", join(projectRoot, ".codex", "skills", "expect"));
 
       const result = ensureAgentSymlink(projectRoot, "codex");
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- update `ensureAgentSymlink` to replace existing non-symlink `expect` paths (including directories/files created by `skills.sh`) with the expected symlink
- keep existing behavior for already-correct symlinks and mismatched symlinks
- add regression coverage for replacing a pre-existing non-symlink skill directory
- handle broken symlink paths by replacing them with the correct symlink target

## Context
This fixes installation failures like:
- `.codex/skills/expect exists and is not a symlink`
- `.cursor/skills/expect exists and is not a symlink`
- `.opencode/skills/expect exists and is not a symlink`

when users have an existing `expect` folder from `skills.sh`.

## Validation
- ✅ `pnpm test add-skill` (in `apps/cli`)
- ⚠️ `pnpm typecheck` fails due to pre-existing issues in `packages/browser` (missing generated runtime files and unrelated typing errors)
- ⚠️ `pnpm test` fails due to environment-dependent cookie tests in `packages/cookies`
- ✅ `pnpm build` succeeds
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://million-js.slack.com/archives/C09BLPH3B1R/p1775173075217309?thread_ts=1775173075.217309&cid=C09BLPH3B1R)

<div><a href="https://cursor.com/agents/bc-57712bb4-faaa-5eef-8200-d114ca3bf0ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-57712bb4-faaa-5eef-8200-d114ca3bf0ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace any pre-existing non-symlink or broken `expect` skill path with the correct symlink during CLI install. Keeps valid symlinks; replaces mismatched, broken, or directory/file paths with `../../.agents/skills/expect`.

- **Bug Fixes**
  - Fixes installs when `.codex/skills/expect`, `.cursor/skills/expect`, or `.opencode/skills/expect` already exist as a folder/file or as a broken/mismatched symlink by removing them and linking to `../../.agents/skills/expect`.
  - Adds tests for replacing a non-symlink directory and a broken symlink.

<sup>Written for commit c903e1c06a03ade1cb8a8678765395c3bbf42ce9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

