### PR TITLE
Handle MCP disconnect cleanup

### DIFF
--- a/apps/cli/tests/mcp-subcommand.test.ts
+++ b/apps/cli/tests/mcp-subcommand.test.ts
@@ -5,6 +5,24 @@ import { describe, expect, it } from "vite-plus/test";
 
 const CLI_BIN = path.resolve(__dirname, "../dist/index.js");
 const MCP_BIN = path.resolve(__dirname, "../dist/browser-mcp.js");
+const MCP_PROCESS_EXIT_TIMEOUT_MS = 3_000;
+
+const waitForExit = (child: ReturnType<typeof spawn>, timeoutMs = MCP_PROCESS_EXIT_TIMEOUT_MS) =>
+  new Promise<{ code: number | null; signal: NodeJS.Signals | null }>((resolve, reject) => {
+    let settled = false;
+    const timeout = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      reject(new Error(`Process ${child.pid} did not exit within ${timeoutMs}ms`));
+    }, timeoutMs);
+
+    child.once("exit", (code, signal) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      resolve({ code, signal });
+    });
+  });
 
 describe("mcp subcommand", () => {
   it("browser-mcp.js exists in dist", () => {
@@ -58,5 +76,26 @@ describe("mcp subcommand", () => {
 
     child.kill();
     await new Promise<void>((resolve) => child.on("exit", resolve));
+  });
+
+  it("direct browser-mcp.js exits when stdin closes", async () => {
+    const child = spawn(process.execPath, [MCP_BIN], {
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    let stderr = "";
+    child.stderr?.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 500));
+
+    expect(child.exitCode).toBeNull();
+    child.stdin?.end();
+
+    const result = await waitForExit(child);
+    expect(result.code).toBe(0);
+    expect(result.signal).toBeNull();
+    expect(stderr).not.toContain("cleanup failed");
   });
 });

--- a/packages/browser/src/mcp/register-process-cleanup.ts
+++ b/packages/browser/src/mcp/register-process-cleanup.ts
@@ -21,12 +21,15 @@ let cleanupRegistered = false;
 const SIGNALS: readonly SignalShutdownReason[] =
   process.platform === "win32" ? WINDOWS_SIGNALS : UNIX_SIGNALS;
 
-const formatError = (error: unknown) => (error instanceof Error ? error.stack ?? error.message : String(error));
+const formatError = (error: unknown) =>
+  error instanceof Error ? (error.stack ?? error.message) : String(error);
 
-const writeShutdownError = (stage: "cleanup" | "afterCleanup", reason: ShutdownReason, error: unknown) => {
-  process.stderr.write(
-    `expect mcp ${stage} failed during ${reason}: ${formatError(error)}\n`,
-  );
+const writeShutdownError = (
+  stage: "cleanup" | "afterCleanup",
+  reason: ShutdownReason,
+  error: unknown,
+) => {
+  process.stderr.write(`expect mcp ${stage} failed during ${reason}: ${formatError(error)}\n`);
 };
 
 export const registerProcessCleanup = (options: RegisterProcessCleanupOptions) => {
@@ -40,7 +43,8 @@ export const registerProcessCleanup = (options: RegisterProcessCleanupOptions) =
     exitAfterCleanup = exitAfterCleanup || shouldExit;
     if (shutdownPromise) return;
 
-    shutdownPromise = options.cleanup(reason)
+    shutdownPromise = options
+      .cleanup(reason)
       .catch((error) => {
         writeShutdownError("cleanup", reason, error);
       })

--- a/packages/browser/src/mcp/register-process-cleanup.ts
+++ b/packages/browser/src/mcp/register-process-cleanup.ts
@@ -1,0 +1,90 @@
+import type { Signal } from "node:process";
+
+const UNIX_SIGNALS = ["SIGINT", "SIGTERM", "SIGHUP"] as const;
+const WINDOWS_SIGNALS = ["SIGINT", "SIGTERM", "SIGBREAK"] as const;
+
+type SignalShutdownReason = (typeof UNIX_SIGNALS)[number] | (typeof WINDOWS_SIGNALS)[number];
+
+export type ShutdownReason =
+  | SignalShutdownReason
+  | "beforeExit"
+  | "disconnect"
+  | "stdin-close"
+  | "stdin-end";
+
+interface RegisterProcessCleanupOptions {
+  readonly cleanup: (reason: ShutdownReason) => Promise<void>;
+  readonly afterCleanup?: (reason: ShutdownReason) => Promise<void> | void;
+  readonly watchStdin?: boolean;
+}
+
+let cleanupRegistered = false;
+
+const SIGNALS: readonly SignalShutdownReason[] =
+  process.platform === "win32" ? WINDOWS_SIGNALS : UNIX_SIGNALS;
+
+const formatError = (error: unknown) => (error instanceof Error ? error.stack ?? error.message : String(error));
+
+const writeShutdownError = (stage: "cleanup" | "afterCleanup", reason: ShutdownReason, error: unknown) => {
+  process.stderr.write(
+    `expect mcp ${stage} failed during ${reason}: ${formatError(error)}\n`,
+  );
+};
+
+export const registerProcessCleanup = (options: RegisterProcessCleanupOptions) => {
+  if (cleanupRegistered) return;
+  cleanupRegistered = true;
+
+  let exitAfterCleanup = false;
+  let shutdownPromise: Promise<void> | undefined;
+
+  const requestShutdown = (reason: ShutdownReason, shouldExit: boolean) => {
+    exitAfterCleanup = exitAfterCleanup || shouldExit;
+    if (shutdownPromise) return;
+
+    shutdownPromise = options.cleanup(reason)
+      .catch((error) => {
+        writeShutdownError("cleanup", reason, error);
+      })
+      .then(() => options.afterCleanup?.(reason))
+      .catch((error) => {
+        writeShutdownError("afterCleanup", reason, error);
+      })
+      .then(() => {
+        if (exitAfterCleanup) {
+          process.exit(0);
+        }
+      });
+  };
+
+  for (const signal of SIGNALS) {
+    process.once(signal as Signal, () => {
+      requestShutdown(signal, true);
+    });
+  }
+
+  process.once("beforeExit", () => {
+    requestShutdown("beforeExit", false);
+  });
+
+  process.once("disconnect", () => {
+    requestShutdown("disconnect", true);
+  });
+
+  if (options.watchStdin) {
+    if (process.stdin.readableEnded) {
+      requestShutdown("stdin-end", true);
+      return;
+    }
+    if (process.stdin.destroyed) {
+      requestShutdown("stdin-close", true);
+      return;
+    }
+    process.stdin.once("end", () => {
+      requestShutdown("stdin-end", true);
+    });
+    process.stdin.once("close", () => {
+      requestShutdown("stdin-close", true);
+    });
+  }
+};

--- a/packages/browser/src/mcp/register-process-cleanup.ts
+++ b/packages/browser/src/mcp/register-process-cleanup.ts
@@ -1,5 +1,3 @@
-import type { Signal } from "node:process";
-
 const UNIX_SIGNALS = ["SIGINT", "SIGTERM", "SIGHUP"] as const;
 const WINDOWS_SIGNALS = ["SIGINT", "SIGTERM", "SIGBREAK"] as const;
 
@@ -58,7 +56,7 @@ export const registerProcessCleanup = (options: RegisterProcessCleanupOptions) =
   };
 
   for (const signal of SIGNALS) {
-    process.once(signal as Signal, () => {
+    process.once(signal as NodeJS.Signals, () => {
       requestShutdown(signal, true);
     });
   }

--- a/packages/browser/src/mcp/start-http.ts
+++ b/packages/browser/src/mcp/start-http.ts
@@ -2,6 +2,7 @@ import * as fs from "node:fs";
 import * as http from "node:http";
 import { Effect, Predicate } from "effect";
 import { McpSession } from "./mcp-session";
+import { registerProcessCleanup } from "./register-process-cleanup";
 import { McpRuntime } from "./runtime";
 import { createBrowserMcpServer } from "./server";
 import { CLI_SESSION_FILE, MAX_DAEMON_REQUEST_BODY_BYTES } from "./constants";
@@ -89,17 +90,20 @@ const closeSession = Effect.gen(function* () {
   yield* session.close();
 });
 
-const shutdown = () => {
-  void McpRuntime.runPromise(closeSession).finally(() => {
+registerProcessCleanup({
+  cleanup: () => McpRuntime.runPromise(closeSession),
+  afterCleanup: async () => {
     removeSessionFile();
-    process.exit(0);
-  });
-};
-
-process.once("SIGINT", shutdown);
-process.once("SIGTERM", shutdown);
-process.once("beforeExit", () => {
-  void McpRuntime.runPromise(closeSession).finally(removeSessionFile);
+    await new Promise<void>((resolve, reject) => {
+      httpServer.close((error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve();
+      });
+    });
+  },
 });
 
 httpServer.listen(0, "127.0.0.1", () => {

--- a/packages/browser/src/mcp/start.ts
+++ b/packages/browser/src/mcp/start.ts
@@ -1,29 +1,17 @@
 import { Effect } from "effect";
 import { McpSession } from "./mcp-session";
+import { registerProcessCleanup } from "./register-process-cleanup";
 import { McpRuntime } from "./runtime";
 import { startBrowserMcpServer } from "./server";
-
-let cleanupRegistered = false;
 
 const closeSession = Effect.gen(function* () {
   const session = yield* McpSession;
   yield* session.close();
 });
 
-const registerProcessCleanup = () => {
-  if (cleanupRegistered) return;
-  cleanupRegistered = true;
+registerProcessCleanup({
+  cleanup: () => McpRuntime.runPromise(closeSession),
+  watchStdin: true,
+});
 
-  const handleShutdown = () => {
-    void McpRuntime.runPromise(closeSession).finally(() => process.exit(0));
-  };
-
-  process.once("SIGINT", handleShutdown);
-  process.once("SIGTERM", handleShutdown);
-  process.once("beforeExit", () => {
-    void McpRuntime.runPromise(closeSession);
-  });
-};
-
-registerProcessCleanup();
 void startBrowserMcpServer(McpRuntime);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a shared MCP process-cleanup helper so stdio and daemon entrypoints both run teardown exactly once
- make the stdio MCP exit when the client disconnects or stdin closes, which shuts down Playwright/Chromium cleanup instead of leaving `browser-mcp.js` orphaned
- reuse the helper for the HTTP daemon cleanup path and add a regression test covering stdio stdin shutdown
- format the new cleanup helper so the browser package format check passes in CI

## Testing
- `pnpm --filter @expect/browser format:check`
- `node -e '... spawn("apps/cli/dist/browser-mcp.js") ... child.stdin.end() ...'` (verified the rebuilt MCP process exits after stdin closes)
- `pnpm --filter expect-sdk build`
- `pnpm --filter expect-cli test -- tests/mcp-subcommand.test.ts`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test` *(fails in unrelated environment-dependent `@expect/cookies` tests: `tests/browsers.test.ts > returns at least 2 browsers` and `tests/cookies.test.ts > extracts cookies from at least one detected browser` because only one browser / zero cookies are available in this CI environment)*

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-58b5ba1c-02f7-4f80-97a2-8e0891d187ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-58b5ba1c-02f7-4f80-97a2-8e0891d187ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralized MCP shutdown handling to prevent orphaned browser processes. The stdio MCP now exits on client disconnect or stdin close, and the HTTP daemon cleans up reliably.

- **Bug Fixes**
  - Stdio MCP exits on disconnect, stdin end, or stdin close to tear down browser trees.
  - HTTP daemon now closes the session, removes the CLI session file, and closes the `httpServer` on cleanup.
  - Added a regression test to ensure `browser-mcp.js` exits when stdin closes and logs no cleanup errors.

- **Refactors**
  - Introduced `register-process-cleanup` to handle `SIGINT`/`SIGTERM`/`SIGHUP` (or `SIGBREAK` on Windows), `beforeExit`, `disconnect`, and optional stdin watching.
  - Fixed type annotations in the cleanup helper.
  - Formatted the cleanup helper to satisfy package format checks.

<sup>Written for commit b10aeeb59c7f26074026a3c6aec03360eddd48a7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

